### PR TITLE
Supports C#7.3, and changes generic constraints in Item

### DIFF
--- a/secs4net/Core/Secs4Net/Item.cs
+++ b/secs4net/Core/Secs4Net/Item.cs
@@ -107,7 +107,7 @@ namespace Secs4Net
         /// <summary>
         /// get value by specific type
         /// </summary>
-        public T GetValue<T>() where T : struct
+        public T GetValue<T>() where T : unmanaged
         {
             if (Format == SecsFormat.List)
                 throw new InvalidOperationException("The item is a list");
@@ -128,7 +128,7 @@ namespace Secs4Net
         /// <summary>
         /// get value array by specific type
         /// </summary>
-        public T[] GetValues<T>() where T : struct
+        public T[] GetValues<T>() where T : unmanaged
         {
             if (Format == SecsFormat.List)
                 throw new InvalidOperationException("The item is list");
@@ -231,7 +231,7 @@ namespace Secs4Net
             return sb.ToString();
 
             string JoinAsString<T>(IEnumerable src)
-                where T : struct => string.Join(" ", Unsafe.As<T[]>(src));
+                where T : unmanaged => string.Join(" ", Unsafe.As<T[]>(src));
         }
 
         #region Type Casting Operator
@@ -406,7 +406,7 @@ namespace Secs4Net
                 default: throw new ArgumentException(@"Invalid format", nameof(format));
             }
 
-            T[] Decode<T>(byte[] data2, in int index2, in int length2) where T : struct
+            T[] Decode<T>(byte[] data2, in int index2, in int length2) where T : unmanaged
             {
                 var elmSize = Unsafe.SizeOf<T>();
                 data2.Reverse(index2, index2 + length2, elmSize);

--- a/secs4net/Core/Secs4Net/Secs4Net.csproj
+++ b/secs4net/Core/Secs4Net/Secs4Net.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/secs4net/Core/Secs4Net/Secs4Net.csproj
+++ b/secs4net/Core/Secs4Net/Secs4Net.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>default</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/secs4net/Extension/Serialization.Json/JsonExtension.cs
+++ b/secs4net/Extension/Serialization.Json/JsonExtension.cs
@@ -142,7 +142,7 @@ namespace Secs4Net.Json
             }
             writer.WriteEndObject();
 
-            void WriteValue<T>(JsonTextWriter w, Item i) where T : struct
+            void WriteValue<T>(JsonTextWriter w, Item i) where T : unmanaged
             {
                 w.WriteStartArray();
                 foreach (var v in i.GetValues<T>())
@@ -195,7 +195,7 @@ namespace Secs4Net.Json
             }
 
             async Task WriteValueAsync<T>(JsonWriter w, Item i)
-                where T : struct
+                where T : unmanaged
             {
                 await w.WriteStartArrayAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
`Item` class has some APIs  which generic typearg are constrained as `struct`.
But in SECS-II standard their item is only primitive type but not complex struct.

On C#7.3 we can use `unmanaged` constraint, so this pull request tightens generic constraint for `Item` class and its dependency.