### PR TITLE
Ignore the direction bit of the Device ID

### DIFF
--- a/src/Secs4Net.Sml/SmlReader.cs
+++ b/src/Secs4Net.Sml/SmlReader.cs
@@ -74,18 +74,18 @@ public static class SmlReader
             int j = line.IndexOf('F');
 
 #if NET
-            var s = byte.Parse(line[i..j]);
+            var s = byte.Parse(line[i..j], provider: CultureInfo.InvariantCulture);
 #else
-            var s = byte.Parse(line[i..j].ToString());
+            var s = byte.Parse(line[i..j].ToString(), CultureInfo.InvariantCulture);
 #endif
 
             line = line[(j + 1)..];
             i = line.IndexOf('\'');
 
 #if NET
-            var f = byte.Parse(line[0..i]);
+            var f = byte.Parse(line[0..i], provider: CultureInfo.InvariantCulture);
 #else
-            var f = byte.Parse(line[0..i].ToString());
+            var f = byte.Parse(line[0..i].ToString(), CultureInfo.InvariantCulture);
 #endif
 
             var replyExpected = line[i..].IndexOf('W') != -1;
@@ -116,18 +116,18 @@ public static class SmlReader
         int j = line.IndexOf('F');
 
 #if NET
-        var s = byte.Parse(line[i..j]);
+        var s = byte.Parse(line[i..j], provider: CultureInfo.InvariantCulture);
 #else
-        var s = byte.Parse(line[i..j].ToString());
+        var s = byte.Parse(line[i..j].ToString(), CultureInfo.InvariantCulture);
 #endif
 
         line = line[(j + 1)..];
         i = line.IndexOf('\'');
 
 #if NET
-        var f = byte.Parse(line[0..i]);
+        var f = byte.Parse(line[0..i], provider: CultureInfo.InvariantCulture);
 #else
-        var f = byte.Parse(line[0..i].ToString());
+        var f = byte.Parse(line[0..i].ToString(), CultureInfo.InvariantCulture);
 #endif
 
         var replyExpected = line[i..].IndexOf('W') != -1;
@@ -226,38 +226,38 @@ public static class SmlReader
     private static byte HexByteParser(ReadOnlySpan<char> str)
 #if NET
         => str.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
-        ? byte.Parse(str[2..], NumberStyles.HexNumber)
-        : byte.Parse(str);
+        ? byte.Parse(str[2..], NumberStyles.HexNumber, provider: CultureInfo.InvariantCulture)
+        : byte.Parse(str, provider: CultureInfo.InvariantCulture);
 #else
         => str.StartsWith("0x".AsSpan(), StringComparison.OrdinalIgnoreCase)
-        ? byte.Parse(str[2..].ToString(), NumberStyles.HexNumber)
-        : byte.Parse(str.ToString());
+        ? byte.Parse(str[2..].ToString(), NumberStyles.HexNumber, CultureInfo.InvariantCulture)
+        : byte.Parse(str.ToString(), CultureInfo.InvariantCulture);
 #endif
 
     private static readonly (Func<Item>, Func<byte[], Item>, SpanParser<byte>) BinaryParser = (B, B, HexByteParser);
 #if NET
-    private static readonly (Func<Item>, Func<sbyte[], Item>, SpanParser<sbyte>) I1Parser = (I1, I1, static span => sbyte.Parse(span));
-    private static readonly (Func<Item>, Func<short[], Item>, SpanParser<short>) I2Parser = (I2, I2, static span => short.Parse(span));
-    private static readonly (Func<Item>, Func<int[], Item>, SpanParser<int>) I4Parser = (I4, I4, static span => int.Parse(span));
-    private static readonly (Func<Item>, Func<long[], Item>, SpanParser<long>) I8Parser = (I8, I8, static span => long.Parse(span));
-    private static readonly (Func<Item>, Func<byte[], Item>, SpanParser<byte>) U1Parser = (U1, U1, static span => byte.Parse(span));
-    private static readonly (Func<Item>, Func<ushort[], Item>, SpanParser<ushort>) U2Parser = (U2, U2, static span => ushort.Parse(span));
-    private static readonly (Func<Item>, Func<uint[], Item>, SpanParser<uint>) U4Parser = (U4, U4, static span => uint.Parse(span));
-    private static readonly (Func<Item>, Func<ulong[], Item>, SpanParser<ulong>) U8Parser = (U8, U8, static span => ulong.Parse(span));
-    private static readonly (Func<Item>, Func<float[], Item>, SpanParser<float>) F4Parser = (F4, F4, static span => float.Parse(span));
-    private static readonly (Func<Item>, Func<double[], Item>, SpanParser<double>) F8Parser = (F8, F8, static span => double.Parse(span));
+    private static readonly (Func<Item>, Func<sbyte[], Item>, SpanParser<sbyte>) I1Parser = (I1, I1, static span => sbyte.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<short[], Item>, SpanParser<short>) I2Parser = (I2, I2, static span => short.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<int[], Item>, SpanParser<int>) I4Parser = (I4, I4, static span => int.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<long[], Item>, SpanParser<long>) I8Parser = (I8, I8, static span => long.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<byte[], Item>, SpanParser<byte>) U1Parser = (U1, U1, static span => byte.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<ushort[], Item>, SpanParser<ushort>) U2Parser = (U2, U2, static span => ushort.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<uint[], Item>, SpanParser<uint>) U4Parser = (U4, U4, static span => uint.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<ulong[], Item>, SpanParser<ulong>) U8Parser = (U8, U8, static span => ulong.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<float[], Item>, SpanParser<float>) F4Parser = (F4, F4, static span => float.Parse(span, provider: CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<double[], Item>, SpanParser<double>) F8Parser = (F8, F8, static span => double.Parse(span, provider: CultureInfo.InvariantCulture));
     private static readonly (Func<Item>, Func<bool[], Item>, SpanParser<bool>) BoolParser = (Boolean, Boolean, bool.Parse);
 #else
-    private static readonly (Func<Item>, Func<sbyte[], Item>, SpanParser<sbyte>) I1Parser = (I1, I1, static span => sbyte.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<short[], Item>, SpanParser<short>) I2Parser = (I2, I2, static span => short.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<int[], Item>, SpanParser<int>) I4Parser = (I4, I4, static span => int.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<long[], Item>, SpanParser<long>) I8Parser = (I8, I8, static span => long.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<byte[], Item>, SpanParser<byte>) U1Parser = (U1, U1, static span => byte.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<ushort[], Item>, SpanParser<ushort>) U2Parser = (U2, U2, static span => ushort.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<uint[], Item>, SpanParser<uint>) U4Parser = (U4, U4, static span => uint.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<ulong[], Item>, SpanParser<ulong>) U8Parser = (U8, U8, static span => ulong.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<float[], Item>, SpanParser<float>) F4Parser = (F4, F4, static span => float.Parse(span.ToString()));
-    private static readonly (Func<Item>, Func<double[], Item>, SpanParser<double>) F8Parser = (F8, F8, static span => double.Parse(span.ToString()));
+    private static readonly (Func<Item>, Func<sbyte[], Item>, SpanParser<sbyte>) I1Parser = (I1, I1, static span => sbyte.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<short[], Item>, SpanParser<short>) I2Parser = (I2, I2, static span => short.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<int[], Item>, SpanParser<int>) I4Parser = (I4, I4, static span => int.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<long[], Item>, SpanParser<long>) I8Parser = (I8, I8, static span => long.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<byte[], Item>, SpanParser<byte>) U1Parser = (U1, U1, static span => byte.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<ushort[], Item>, SpanParser<ushort>) U2Parser = (U2, U2, static span => ushort.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<uint[], Item>, SpanParser<uint>) U4Parser = (U4, U4, static span => uint.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<ulong[], Item>, SpanParser<ulong>) U8Parser = (U8, U8, static span => ulong.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<float[], Item>, SpanParser<float>) F4Parser = (F4, F4, static span => float.Parse(span.ToString(), CultureInfo.InvariantCulture));
+    private static readonly (Func<Item>, Func<double[], Item>, SpanParser<double>) F8Parser = (F8, F8, static span => double.Parse(span.ToString(), CultureInfo.InvariantCulture));
     private static readonly (Func<Item>, Func<bool[], Item>, SpanParser<bool>) BoolParser = (Boolean, Boolean, static span => bool.Parse(span.ToString()));
 #endif
     private static readonly (Func<Item>, Func<string, Item>) AParser = (A, A);

--- a/src/Secs4Net.Sml/SmlWriter.cs
+++ b/src/Secs4Net.Sml/SmlWriter.cs
@@ -28,9 +28,9 @@ public static class SmlWriter
             writer.Write(':');
         }
         writer.Write("'S");
-        writer.Write(msg.S);
+        writer.Write(msg.S.ToString(CultureInfo.InvariantCulture));
         writer.Write('F');
-        writer.Write(msg.F);
+        writer.Write(msg.F.ToString(CultureInfo.InvariantCulture));
         writer.Write('\'');
         if (msg.ReplyExpected)
         {
@@ -50,19 +50,19 @@ public static class SmlWriter
     {
         if (msg.Name is not null)
         {
-            writer.Write(msg.Name);
-            writer.Write(':');
+            await writer.WriteAsync(msg.Name);
+            await writer.WriteAsync(':');
         }
-        writer.Write("'S");
-        writer.Write(msg.S);
-        writer.Write('F');
-        writer.Write(msg.F);
-        writer.Write('\'');
+        await writer.WriteAsync("'S");
+        await writer.WriteAsync(msg.S.ToString(CultureInfo.InvariantCulture));
+        await writer.WriteAsync('F');
+        await writer.WriteAsync(msg.F.ToString(CultureInfo.InvariantCulture));
+        await writer.WriteAsync('\'');
         if (msg.ReplyExpected)
         {
-            writer.Write('W');
+            await writer.WriteAsync('W');
         }
-        writer.WriteLine();
+        await writer.WriteLineAsync();
 
         if (msg.SecsItem is not null)
         {
@@ -79,7 +79,7 @@ public static class SmlWriter
         writer.Write('<');
         writer.Write(item.Format.ToSml());
         writer.Write(" [");
-        writer.Write(item.Count);
+        writer.Write(item.Count.ToString(CultureInfo.InvariantCulture));
         writer.Write("] ");
         switch (item.Format)
         {
@@ -151,9 +151,9 @@ public static class SmlWriter
                 break;
             case SecsFormat.ASCII:
             case SecsFormat.JIS8:
-                writer.Write('\'');
-                writer.Write(item.GetString());
-                writer.Write('\'');
+                await writer.WriteAsync('\'');
+                await writer.WriteAsync(item.GetString());
+                await writer.WriteAsync('\'');
                 break;
             case SecsFormat.Binary:
                 writer.WriteHexArray(item.GetMemory<byte>());
@@ -214,7 +214,7 @@ public static class SmlWriter
 #if NET6_0
             where T : unmanaged, ISpanFormattable
 #else
-            where T: unmanaged
+            where T: unmanaged, IConvertible
 #endif
     {
         if (memory.IsEmpty)
@@ -238,7 +238,7 @@ public static class SmlWriter
 #if NET6_0
                 => writer.WriteSpanFormattableValue(value);
 #else
-                => writer.Write(value.ToString());
+                => writer.Write(value.ToString(CultureInfo.InvariantCulture));
 #endif
     }
 

--- a/src/Secs4Net.Sml/SmlWriter.cs
+++ b/src/Secs4Net.Sml/SmlWriter.cs
@@ -16,7 +16,7 @@ public static class SmlWriter
 
     public static string ToSml(this SecsMessage msg)
     {
-        using var sw = new StringWriter();
+        using var sw = new StringWriter(CultureInfo.InvariantCulture);
         msg.WriteSmlTo(sw);
         return sw.ToString();
     }

--- a/src/Secs4Net/MessageHeader.cs
+++ b/src/Secs4Net/MessageHeader.cs
@@ -34,14 +34,14 @@ public readonly record struct MessageHeader
     internal static void Decode(ReadOnlySpan<byte> buffer, out MessageHeader header)
     {
         ref var head = ref MemoryMarshal.GetReference(buffer);
-        var s = Unsafe.Add(ref head, 2);
+        var s = buffer[2];
         header = new MessageHeader
         {
             DeviceId = (ushort)(BinaryPrimitives.ReadUInt16BigEndian(buffer) & 0b01111111_11111111),
             ReplyExpected = (s & 0b1000_0000) != 0,
-            S = (byte)(s & 0b0111_111),
-            F = Unsafe.Add(ref head, 3),
-            MessageType = (MessageType)Unsafe.Add(ref head, 5),
+            S = (byte)(s & 0b0111_1111),
+            F = buffer[3],
+            MessageType = (MessageType)buffer[5],
             Id = BinaryPrimitives.ReadInt32BigEndian(buffer[6..]),
         };
     }

--- a/src/Secs4Net/MessageHeader.cs
+++ b/src/Secs4Net/MessageHeader.cs
@@ -37,7 +37,7 @@ public readonly record struct MessageHeader
         var s = Unsafe.Add(ref head, 2);
         header = new MessageHeader
         {
-            DeviceId = BinaryPrimitives.ReadUInt16BigEndian(buffer),
+            DeviceId = (ushort)(BinaryPrimitives.ReadUInt16BigEndian(buffer) & 0b01111111_11111111),
             ReplyExpected = (s & 0b1000_0000) != 0,
             S = (byte)(s & 0b0111_111),
             F = Unsafe.Add(ref head, 3),

--- a/src/Secs4Net/MessageType.cs
+++ b/src/Secs4Net/MessageType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Secs4Net;
 
-public enum MessageType : byte
+public enum MessageType : ushort
 {
     DataMessage = 0b0000_0000,
     SelectRequest = 0b0000_0001,

--- a/src/Secs4Net/MessageType.cs
+++ b/src/Secs4Net/MessageType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Secs4Net;
 
-public enum MessageType : ushort
+public enum MessageType : byte
 {
     DataMessage = 0b0000_0000,
     SelectRequest = 0b0000_0001,

--- a/test/Secs4Net.UnitTests/MessageHeader.UnitTests.cs
+++ b/test/Secs4Net.UnitTests/MessageHeader.UnitTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Secs4Net.UnitTests;
+
+public class MessageHeaderUnitTests
+{
+    [Fact]
+    public void Header_should_ignore_direction_in_device_id()
+    {
+        /*
+         * Equipment to Host
+         * Device ID 1
+         * Reply expected
+         * S6F11
+         * Select request
+         * ID: 1
+         */
+        var headerBytes = new byte[] { 128, 1, 134, 11, 0, 1, 0, 0, 0, 1 };
+        MessageHeader.Decode(headerBytes, out MessageHeader header);
+
+        Assert.Multiple(
+            () => Assert.Equal(1, header.DeviceId),
+            () => Assert.True(header.ReplyExpected),
+            () => Assert.Equal(6, header.S),
+            () => Assert.Equal(11, header.F),
+            () => Assert.Equal(MessageType.SelectRequest, header.MessageType),
+            () => Assert.Equal(1, header.Id));
+    }
+}


### PR DESCRIPTION
Fixes the extraction of the Device ID from the header. We had issues with our machine because it sets the Equipment-to-Host direction bit, which is the first bit in the 2 bytes for the Device ID. This resulted in the ID being parsed as 32769 (`0b10000000_00000001`) instead of 1 (`0b00000000_00000001`) which was configured on both sites and was correctly transmitted (with that R-Bit). This PR simply removes the first bit from the 2 Device ID bytes, since it's not part of the Device ID.

I don't think the spec is public, but this document helped me debug that issue: [Guide_to_understanding_SECS.pdf](http://www.edgeintegration.com/downloads/Guide_to_understanding_SECS.pdf)

Screenshot from that PDF:
![image](https://user-images.githubusercontent.com/71644972/234023201-9765dc06-a914-434a-a383-7d7049d71632.png)
