### PR TITLE
Bug fix with issues 75 and issues 86

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Copyright>Copyright © secs4net 2021</Copyright>
     <RepositoryUrl>https://github.com/mkjeff/secs4net</RepositoryUrl>
     <Authors>mkjeff</Authors>

--- a/src/Secs4Net/Item.Decode.cs
+++ b/src/Secs4Net/Item.Decode.cs
@@ -31,9 +31,9 @@ public partial class Item
     public static unsafe Item DecodeFromFullBuffer(ref ReadOnlySequence<byte> bytes)
     {
 #if NET
-        DecodeFormatAndLengthByteCount(bytes.FirstSpan.DangerousGetReferenceAt(0), out var format, out var lengthByteCount);
+        DecodeFormatAndLengthByteCount(bytes.Slice(0, 1).ToArray()[0], out var format, out var lengthByteCount);
 #else
-        DecodeFormatAndLengthByteCount(bytes.First.Span.DangerousGetReferenceAt(0), out var format, out var lengthByteCount);
+        DecodeFormatAndLengthByteCount(bytes.Slice(0, 1).ToArray()[0], out var format, out var lengthByteCount);
 #endif
 
         var dataLengthSeq = bytes.Slice(1, lengthByteCount);


### PR DESCRIPTION
#### 利用 [issues 75](https://github.com/mkjeff/secs4net/issues/75) 的方法，解决了此问题（尚未知道原因，望指教）。
将 ItemDecode.cs 中的
```csharp
public static unsafe Item DecodeFromFullBuffer(ref ReadOnlySequence<byte> bytes)
```
方法中的
```csharp
DecodeFormatAndLengthByteCount(bytes.FirstSpan.DangerousGetReferenceAt(0), out var format, out var lengthByteCount);
```
语句替换为
```csharp
var itemLenByte = bytes.Slice(0, 1).ToArray()[0];
//Trace.WriteLine(itemLenByte+"-<Different>-" + bytes.FirstSpan.DangerousGetReferenceAt(0));
DecodeFormatAndLengthByteCount(itemLenByte, out var format, out var lengthByteCount);
```